### PR TITLE
Updated percy/exec-action to @percy/cli exec

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,9 +16,7 @@ jobs:
       - name: Install dependencies
         run: npm ci
       - name: Run tests
-        uses: percy/exec-action@v0.3.1
-        with:
-          custom-command: "npm test"
+        run: npm test
         env:
           PERCY_TOKEN: ${{ secrets.PERCY_TOKEN }}
 


### PR DESCRIPTION
### Summary

- Updated workflow to use `@percy/cli exec` instead of deprecated `percy/exec-action`